### PR TITLE
Add draft overview page and resource reference topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # pet-adoption-service
+
+For the REST API docs, see the [Pet Adoption service docs](https://syangabq.github.io/pet-adoption-service/).
+
+## Proposed Information Architecture
+
+* Overview
+* Installation
+* Quickstart
+    * Enroll your first user
+* Tutorials
+    * Enroll a new user
+    * Add a new pet
+    * Search for pets with filters
+    * Search for users filtered by interest
+    * Update a pet's adoption status
+* API Reference
+    * User
+        * Get all users
+        * Get user by ID
+        * Enroll a new user
+        * Update a user's interest
+        * Delete a user
+    * Pet
+        * Get all pets
+        * Get pet by ID
+        * Add a new pet
+        * Update a pet's adoption status
+        * Delete a pet

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,8 @@
+title: "Pet Adoption service API"
+remote_theme: just-the-docs/just-the-docs
+color_scheme: "light_contrast"
+search_enabled: false
+callouts:
+  note:
+    title: Note
+    color: blue

--- a/docs/_includes/nav_footer_custom.html
+++ b/docs/_includes/nav_footer_custom.html
@@ -1,0 +1,1 @@
+<footer></footer>

--- a/docs/_sass/color_schemes/light_contrast.scss
+++ b/docs/_sass/color_schemes/light_contrast.scss
@@ -1,0 +1,3 @@
+@import "./color_schemes/light";
+
+$link-color: $grey-dk-300;

--- a/docs/api/pet.md
+++ b/docs/api/pet.md
@@ -1,0 +1,46 @@
+---
+title: Pet
+nav_order: 3
+---
+
+# `pet` resource
+
+Base endpoint:
+
+```shell
+{base_url}/pets
+```
+
+Contains information about pets in the service.
+
+To adopt a pet in the service, the user must first be added to the service. Learn more about the [user resource](user.md).
+
+## Resource properties
+
+Sample `pet` resource:
+
+```js
+{
+    "id": 4,
+    "name": "Fred",
+    "type": "dog",
+    "breed": "Poodle",
+    "age": 24,
+    "color": "brown",
+    "personality": "friendly",
+    "status": "available",
+    "user_id": null
+}
+```
+
+| Property name | Type | Description |
+| ------------- | ----------- | ----------- |
+| `id` | number | The pet's unique record ID. |
+| `name` | string | The pet's name. |
+| `type` | string | The type of pet. <br/> Can be one of: `cat`, `dog` |
+| `breed` | string | The pet's breed. |
+| `age` | number | The pet's age in months. The service will automatically update the value of this property every month. |
+| `color` | string | The pet's color. |
+| `personality` | string | Description of the pet's personality. |
+| `status` | string | The pet's adoption status. <br/> Can be one of: `adopted`, `available` |
+| `user_id` | string \| null | The ID of the user resource representing the user that adopted this pet, or `null` if the pet has not been adopted yet. |

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -1,0 +1,40 @@
+---
+title: User
+nav_order: 2
+---
+
+# `user` resource
+
+Base endpoint:
+
+```shell
+{base_url}/users
+```
+
+Contains information about users of the service.
+
+To adopt a pet in the service, the user must first be added to the service. Learn more about the [pet resource](pet.md).
+
+## Resource properties
+
+Sample `user` resource:
+
+```js
+{
+    "id": 3,
+    "first_name": "Amber",
+    "last_name": "Cross",
+    "email": "across@example.com",
+    "phone": "456-333-8899",
+    "interested_in": "cats"
+}
+```
+
+| Property name | Type | Description |
+| ------------- | ----------- | ----------- |
+| `id` | number | The user's unique record ID. |
+| `first_name` | string | The user's first name. |
+| `last_name` | string | The user's last name. |
+| `email` | string | The user's email address. |
+| `phone` | string | The user's phone number. |
+| `interested_in` | string | The type of pet the user is interested in adopting. <br/> Can be one of: `cats`, `dogs`, `both` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+---
+title: Overview
+layout: home
+nav_order: 1
+---
+
+# Pet Adoption service API
+
+**Help cats and dogs find their forever homes!**
+
+The Pet Adoption service API allows developers to create applications that assist people in adopting cat and dog companions.
+
+## Get started
+
+## API reference
+
+The Pet Adoption service API is a REST API with the following resources:
+
+* [User](api/user.md)
+* [Pet](api/pet.md)
+
+{: .note }
+The docs refer to a `{base_url}` when they refer to the URL of a resource. The `{base_url}` value depends on the installation of the service. When run locally for testing, the `{base_url}` is generally `http://localhost:3000`.


### PR DESCRIPTION
This:

* Adds a draft overview page that builds in GitHub Pages. The theming of the site is very temporary and subject to change!
* Adds a proposed information architecture (topic list) in README.md.
* Adds draft reference topics for the `user` and `pet` resources.