### PR TITLE
Address peer review feedback

### DIFF
--- a/docs/api/pet/index.md
+++ b/docs/api/pet/index.md
@@ -13,6 +13,9 @@ Base endpoint:
 {base_url}/pets
 ```
 
+{: .note }
+The `{base_url}` value depends on the installation of the service. When run locally for testing, the `{base_url}` is generally `http://localhost:3000`.
+
 Contains information about pets in the service.
 
 To adopt a pet in the service, the user must first be added to the service. Learn more about the [user resource](../user/index.md).

--- a/docs/api/user/index.md
+++ b/docs/api/user/index.md
@@ -13,6 +13,9 @@ Base endpoint:
 {base_url}/users
 ```
 
+{: .note }
+The `{base_url}` value depends on the installation of the service. When run locally for testing, the `{base_url}` is generally `http://localhost:3000`.
+
 Contains information about users of the service.
 
 To adopt a pet in the service, the user must first be added to the service. Learn more about the [pet resource](../pet/index.md).

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -23,11 +23,11 @@ In this quickstart, you will:
 
 1. [Set up Git](https://docs.github.com/en/get-started/getting-started-with-git/set-up-git) on your development system.
 
-1. [Clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the [`pet-adoption-service` repo](https://github.com/syangabq/pet-adoption-service).
+1. [Clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the [`pet-adoption-service` repository](https://github.com/syangabq/pet-adoption-service).
 
 ## Start your local Pet Adoption Service
 
-1. In a command-line tool, run the following command to start your local Pet Adoption Service. Replace `<your-github-workspace>` with the directory that contains your clone of the `pet-adoption-service` repo.
+1. In a command-line tool, run the following command to start your local Pet Adoption Service. Replace `<your-github-workspace>` with the directory that contains your clone of the `pet-adoption-service` repository.
 
     ```shell
     cd <your-github-workspace>/pet-adoption-service/api

--- a/docs/support.md
+++ b/docs/support.md
@@ -5,4 +5,4 @@ nav_order: 5
 
 # Support
 
-For any feedback regarding the Pet Adoption Service or the documentation, please [file an issue on GitHub](https://github.com/syangabq/pet-adoption-service/issues).
+For any feedback regarding the Pet Adoption Service or the documentation, please [create a GitHub issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue) for the [`pet-adoption-service` repository](https://github.com/syangabq/pet-adoption-service/issues).

--- a/docs/tutorials/add_a_new_pet.md
+++ b/docs/tutorials/add_a_new_pet.md
@@ -16,12 +16,7 @@ Make sure you have completed the [Get started](../get_started.md) quickstart on 
 
 ## Add a new pet
 
-1. In a command-line tool, run the following command to start your local Pet Adoption Service, if it's not already running. Replace `<your-github-workspace>` with the directory that contains your clone of the `pet-adoption-service` repo.
-
-    ```shell
-    cd <your-github-workspace>/pet-adoption-service/api
-    json-server -w pet-adoption-db-source.json
-    ```
+1. In a command-line tool, [start your local Pet Adoption Service](../get_started.md#start-your-local-pet-adoption-service), if it is not already running.
 
 1. In another command-line window, run this command to make a `POST` request. In the request body, replace:
 

--- a/docs/tutorials/enroll_a_new_user.md
+++ b/docs/tutorials/enroll_a_new_user.md
@@ -16,12 +16,7 @@ Make sure you have completed the [Get started](../get_started.md) quickstart on 
 
 ## Enroll a new user
 
-1. In a command-line tool, run the following command to start your local Pet Adoption Service, if it's not already running. Replace `<your-github-workspace>` with the directory that contains your clone of the `pet-adoption-service` repo.
-
-    ```shell
-    cd <your-github-workspace>/pet-adoption-service/api
-    json-server -w pet-adoption-db-source.json
-    ```
+1. In a command-line tool, [start your local Pet Adoption Service](../get_started.md#start-your-local-pet-adoption-service), if it is not already running.
 
 1. In another command-line window, run this command to make a `POST` request. In the request body, replace:
 

--- a/docs/tutorials/search_for_pets.md
+++ b/docs/tutorials/search_for_pets.md
@@ -16,12 +16,7 @@ Make sure you have completed the [Get started](../get_started.md) quickstart on 
 
 ## Search for pets
 
-1. In a command-line tool, run the following command to start your local Pet Adoption Service, if it's not already running. Replace `<your-github-workspace>` with the directory that contains your clone of the `pet-adoption-service` repo.
-
-    ```shell
-    cd <your-github-workspace>/pet-adoption-service/api
-    json-server -w pet-adoption-db-source.json
-    ```
+1. In a command-line tool, [start your local Pet Adoption Service](../get_started.md#start-your-local-pet-adoption-service), if it is not already running.
 
 1. In another command-line window, run this command to make a `GET` request to list all users enrolled in the service.
 

--- a/docs/tutorials/search_for_users.md
+++ b/docs/tutorials/search_for_users.md
@@ -16,12 +16,7 @@ Make sure you have completed the [Get started](../get_started.md) quickstart on 
 
 ## Search for users
 
-1. In a command-line tool, run the following command to start your local Pet Adoption Service, if it's not already running. Replace `<your-github-workspace>` with the directory that contains your clone of the `pet-adoption-service` repo.
-
-    ```shell
-    cd <your-github-workspace>/pet-adoption-service/api
-    json-server -w pet-adoption-db-source.json
-    ```
+1. In a command-line tool, [start your local Pet Adoption Service](../get_started.md#start-your-local-pet-adoption-service), if it is not already running.
 
 1. In another command-line window, run this command to make a `GET` request to list all users enrolled in the service.
 

--- a/docs/tutorials/update_pet_adoption_status.md
+++ b/docs/tutorials/update_pet_adoption_status.md
@@ -18,12 +18,7 @@ In this tutorial, you will update the adoption status of a pet in the Pet Adopti
 
 ## Update a pet's adoption status
 
-1. In a command-line tool, run the following command to start your local Pet Adoption Service, if it's not already running. Replace `<your-github-workspace>` with the directory that contains your clone of the `pet-adoption-service` repo.
-
-    ```shell
-    cd <your-github-workspace>/pet-adoption-service/api
-    json-server -w pet-adoption-db-source.json
-    ```
+1. In a command-line tool, [start your local Pet Adoption Service](../get_started.md#start-your-local-pet-adoption-service), if it is not already running.
 
 1. In another command-line window, run this command to make a `PATCH` request. In the request body, replace:
 


### PR DESCRIPTION
This primarily:

- Adds the `base_url` note to the User and Pet reference topics.
- Replaces the step for starting a local service in each tutorial with a link to the relevant section in the "Get started" topic.
- Adds a link to the GitHub docs on creating an issue for the support topic.